### PR TITLE
add new endpoint to update strength only

### DIFF
--- a/backend-nodejs/src/controllers/currentRevisionController.js
+++ b/backend-nodejs/src/controllers/currentRevisionController.js
@@ -62,8 +62,8 @@ const CurrentRevisionController = {
     try {
       const { auth_id, revisedSurah } = req.query
 
-      if (!auth_id) {
-        return res.status(400).send({ message: "auth_id is required as a query parameter" })
+      if (!auth_id, !revisedSurah) {
+        return res.status(400).send({ message: "auth_id and revisedSurah are required as a query parameter" })
       }
 
       const user = await UsersModel.findOne({ auth_id })

--- a/backend-nodejs/src/routes/surahs.js
+++ b/backend-nodejs/src/routes/surahs.js
@@ -37,6 +37,20 @@ surahRouter.post("/initialiseSurah", /*authenticateUser,*/ async (req, res, next
 // get the surahTestHistory for a specific surah
 surahRouter.get("/surahHistory", /*authenticateUser,*/ surahController.getSurahHistory);
 
+// update strength only
+surahRouter.put('/updateSurahStrengthOnly', /*authenticateUser,*/ async (req, res, next) => {
+  try {
+    const { auth_id } = req.query
+    await surahController.updateSurah(req, res, () => {
+      next();
+    });
+    const updatedUser = await UsersModel.findOne({ auth_id })
+    res.status(200).send(updatedUser);
+
+  } catch (err) {
+    next(err)
+  }
+})
 
 // update strenght of the surah, currentRevision and revisionSurahs
 surahRouter.put('/updateSurah', /*authenticateUser,*/async (req, res, next) => {
@@ -44,12 +58,10 @@ surahRouter.put('/updateSurah', /*authenticateUser,*/async (req, res, next) => {
   try {
     const { auth_id } = req.query;
     await surahController.updateSurah(req, res, () => {
-      console.log("in stage 1")
       allowFurtherActions = false;
       next();
     });
     await currentRevisionController.updateCurrentRevision(req, res, () => {
-      console.log("in stage 2")
       allowFurtherActions = false;
       next();
     });


### PR DESCRIPTION
I added a new endpoint to update strength only, without touching the currentRevision for situations where the user has manually selected a test, rather than going through the 'todays's practise' surahs. This uses the same controller function that is used for the other update path, but doesn't use the currentRevision controller.